### PR TITLE
add LICENSE file

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,2 @@
-include README.rst ChangeLog
+include README.rst ChangeLog LICENSE
 


### PR DESCRIPTION
Somebody is packaging py-cpuinfo for the Fedora Package Collection. At the moment the LICENSE file is missing in the tarball. It would be nice if you merge this pull request and publish a new py-cpuinfo release on PyPi. Thanks.
