### PR TITLE
Resolves #77: Fix reporting from procinfo, and retrieve from lscpu in…

### DIFF
--- a/cpuinfo/cpuinfo.py
+++ b/cpuinfo/cpuinfo.py
@@ -1279,6 +1279,18 @@ def _get_cpu_info_from_lscpu():
 		if model and model.isdigit():
 			info['model'] = int(model)
 
+		l1_data_cache_size = _get_field(False, output, None, None, 'L1d cache')
+		if l1_data_cache_size:
+			info['l1_data_cache_size'] = l1_data_cache_size
+
+		l1_instruction_cache_size = _get_field(False, output, None, None, 'L1i cache')
+		if l1_instruction_cache_size:
+			info['l1_instruction_cache_size'] = l1_instruction_cache_size
+
+		l3_cache_size = _get_field(False, output, None, None, 'L3 cache')
+		if l3_cache_size:
+			info['l3_cache_size'] = l3_cache_size
+
 		l2_cache_size = _get_field(False, output, None, None, 'L2 cache')
 		if l2_cache_size:
 			info['l2_cache_size'] = l2_cache_size
@@ -1732,7 +1744,7 @@ def CopyNewFields(info, new_info):
 		'raw_arch_string', 'l2_cache_size', 'l2_cache_line_size',
 		'l2_cache_associativity', 'stepping', 'model', 'family',
 		'processor_type', 'extended_model', 'extended_family', 'flags',
-        'l3_cache_size'
+        'l3_cache_size', 'l1_data_cache_size', 'l1_instruction_cache_size'
 	]
 
 	for key in keys:
@@ -1820,6 +1832,8 @@ def main():
 
 		print('Raw Arch String: {0}'.format(info.get('raw_arch_string', '')))
 
+		print('L1 Data Cache Size: {0}'.format(info.get('l1_data_cache_size', '')))
+		print('L1 Instruction Cache Size: {0}'.format(info.get('l1_instruction_cache_size', '')))
 		print('L2 Cache Size: {0}'.format(info.get('l2_cache_size', '')))
 		print('L2 Cache Line Size: {0}'.format(info.get('l2_cache_line_size', '')))
 		print('L2 Cache Associativity: {0}'.format(info.get('l2_cache_associativity', '')))

--- a/cpuinfo/cpuinfo.py
+++ b/cpuinfo/cpuinfo.py
@@ -351,15 +351,18 @@ def to_hz_string(ticks):
 def _parse_cpu_string(cpu_string):
 	# Get location of fields at end of string
 	fields_index = cpu_string.find('(', cpu_string.find('@'))
+	#print(fields_index)
 
 	# Processor Brand
 	processor_brand = cpu_string
 	if fields_index != -1:
 		processor_brand = cpu_string[0 : fields_index].strip()
+	#print('processor_brand: ', processor_brand)
 
 	fields = None
 	if fields_index != -1:
 		fields = cpu_string[fields_index : ]
+	#print('fields: ', fields)
 
 	# Hz
 	scale, hz_brand = _get_hz_string_from_brand(processor_brand)
@@ -372,9 +375,11 @@ def _parse_cpu_string(cpu_string):
 			fields = [f.strip().lower() for f in fields]
 			fields = [f.split(':') for f in fields]
 			fields = [{f[0].strip() : f[1].strip()} for f in fields]
+			#print('fields: ', fields)
 			for field in fields:
 				name = list(field.keys())[0]
 				value = list(field.values())[0]
+				#print('name:{0}, value:{1}'.format(name, value))
 				if name == 'origin':
 					vendor_id = value.strip('"')
 				elif name == 'stepping':
@@ -424,10 +429,11 @@ def _parse_dmesg_output(output):
 			fields = fields.strip().split()
 			fields = [n.strip().split('=') for n in fields]
 			fields = [{n[0].strip().lower() : n[1].strip()} for n in fields]
-
+			#print('fields: ', fields)
 			for field in fields:
 				name = list(field.keys())[0]
 				value = list(field.values())[0]
+				#print('name:{0}, value:{1}'.format(name, value))
 				if name == 'origin':
 					vendor_id = value.strip('"')
 				elif name == 'stepping':
@@ -436,7 +442,7 @@ def _parse_dmesg_output(output):
 					model = int(value.lstrip('0x'), 16)
 				elif name in ['fam', 'family']:
 					family = int(value.lstrip('0x'), 16)
-
+		#print('FIELDS: ', (vendor_id, stepping, model, family))
 
 		# Features
 		flag_lines = []
@@ -1286,10 +1292,6 @@ def _get_cpu_info_from_lscpu():
 		l1_instruction_cache_size = _get_field(False, output, None, None, 'L1i cache')
 		if l1_instruction_cache_size:
 			info['l1_instruction_cache_size'] = l1_instruction_cache_size
-
-		l3_cache_size = _get_field(False, output, None, None, 'L3 cache')
-		if l3_cache_size:
-			info['l3_cache_size'] = l3_cache_size
 
 		l2_cache_size = _get_field(False, output, None, None, 'L2 cache')
 		if l2_cache_size:

--- a/cpuinfo/cpuinfo.py
+++ b/cpuinfo/cpuinfo.py
@@ -351,18 +351,15 @@ def to_hz_string(ticks):
 def _parse_cpu_string(cpu_string):
 	# Get location of fields at end of string
 	fields_index = cpu_string.find('(', cpu_string.find('@'))
-	#print(fields_index)
 
 	# Processor Brand
 	processor_brand = cpu_string
 	if fields_index != -1:
 		processor_brand = cpu_string[0 : fields_index].strip()
-	#print('processor_brand: ', processor_brand)
 
 	fields = None
 	if fields_index != -1:
 		fields = cpu_string[fields_index : ]
-	#print('fields: ', fields)
 
 	# Hz
 	scale, hz_brand = _get_hz_string_from_brand(processor_brand)
@@ -375,11 +372,9 @@ def _parse_cpu_string(cpu_string):
 			fields = [f.strip().lower() for f in fields]
 			fields = [f.split(':') for f in fields]
 			fields = [{f[0].strip() : f[1].strip()} for f in fields]
-			#print('fields: ', fields)
 			for field in fields:
 				name = list(field.keys())[0]
 				value = list(field.values())[0]
-				#print('name:{0}, value:{1}'.format(name, value))
 				if name == 'origin':
 					vendor_id = value.strip('"')
 				elif name == 'stepping':
@@ -429,12 +424,10 @@ def _parse_dmesg_output(output):
 			fields = fields.strip().split()
 			fields = [n.strip().split('=') for n in fields]
 			fields = [{n[0].strip().lower() : n[1].strip()} for n in fields]
-			#print('fields: ', fields)
 
 			for field in fields:
 				name = list(field.keys())[0]
 				value = list(field.values())[0]
-				#print('name:{0}, value:{1}'.format(name, value))
 				if name == 'origin':
 					vendor_id = value.strip('"')
 				elif name == 'stepping':
@@ -444,7 +437,6 @@ def _parse_dmesg_output(output):
 				elif name in ['fam', 'family']:
 					family = int(value.lstrip('0x'), 16)
 
-		#print('FIELDS: ', (vendor_id, stepping, model, family))
 
 		# Features
 		flag_lines = []
@@ -1076,7 +1068,6 @@ def actual_get_cpu_info_from_cpuid():
 
 	# Get the Hz and scale
 	scale, hz_advertised = _get_hz_string_from_brand(processor_brand)
-
 	info = {
 	'vendor_id' : cpuid.get_vendor_id(),
 	'hardware' : '',
@@ -1171,7 +1162,7 @@ def _get_cpu_info_from_proc_cpuinfo():
 		'hardware' : hardware,
 		'brand' : processor_brand,
 
-		'l2_cache_size' : cache_size,
+		'l3_cache_size' : cache_size,
 		'flags' : flags,
 		'vendor_id' : vendor_id,
 		'stepping' : stepping,
@@ -1287,6 +1278,14 @@ def _get_cpu_info_from_lscpu():
 		model = _get_field(False, output, None, None, 'Model')
 		if model and model.isdigit():
 			info['model'] = int(model)
+
+		l2_cache_size = _get_field(False, output, None, None, 'L2 cache')
+		if l2_cache_size:
+			info['l2_cache_size'] = l2_cache_size
+
+		l3_cache_size = _get_field(False, output, None, None, 'L3 cache')
+		if l3_cache_size:
+			info['l3_cache_size'] = l3_cache_size
 
 		# Flags
 		flags = _get_field(False, output, None, None, 'flags', 'Features')
@@ -1732,7 +1731,8 @@ def CopyNewFields(info, new_info):
 		'hz_advertised_raw', 'hz_actual_raw', 'arch', 'bits', 'count',
 		'raw_arch_string', 'l2_cache_size', 'l2_cache_line_size',
 		'l2_cache_associativity', 'stepping', 'model', 'family',
-		'processor_type', 'extended_model', 'extended_family', 'flags'
+		'processor_type', 'extended_model', 'extended_family', 'flags',
+        'l3_cache_size'
 	]
 
 	for key in keys:
@@ -1823,7 +1823,7 @@ def main():
 		print('L2 Cache Size: {0}'.format(info.get('l2_cache_size', '')))
 		print('L2 Cache Line Size: {0}'.format(info.get('l2_cache_line_size', '')))
 		print('L2 Cache Associativity: {0}'.format(info.get('l2_cache_associativity', '')))
-
+		print('L3 Cache Size: {0}'.format(info.get('l3_cache_size', '')))
 		print('Stepping: {0}'.format(info.get('stepping', '')))
 		print('Model: {0}'.format(info.get('model', '')))
 		print('Family: {0}'.format(info.get('family', '')))

--- a/tests/test_linux_aarch64_64.py
+++ b/tests/test_linux_aarch64_64.py
@@ -117,7 +117,7 @@ class TestLinux_Aarch_64(unittest.TestCase):
 	def test_returns(self):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
-		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_lscpu()))
+		self.assertEqual(3, len(cpuinfo._get_cpu_info_from_lscpu()))
 		self.assertEqual(1, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
@@ -126,12 +126,17 @@ class TestLinux_Aarch_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(6, len(cpuinfo.get_cpu_info()))
+		self.assertEqual(9, len(cpuinfo.get_cpu_info()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
 
-		self.assertEqual(0, len(info))
+		self.assertEqual('78K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+
+		self.assertEqual('16384K', info['l2_cache_size'])
+
+		self.assertEqual(3, len(info))
 
 	def test_get_cpu_info_from_proc_cpuinfo(self):
 		info = cpuinfo._get_cpu_info_from_proc_cpuinfo()
@@ -160,9 +165,14 @@ class TestLinux_Aarch_64(unittest.TestCase):
 
 		self.assertEqual('aarch64', info['raw_arch_string'])
 
-		self.assertEqual('', info['l2_cache_size'])
+		self.assertEqual('78K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+
+		self.assertEqual('16384K', info['l2_cache_size'])
 		self.assertEqual(0, info['l2_cache_line_size'])
 		self.assertEqual(0, info['l2_cache_associativity'])
+
+		self.assertEqual('', info['l3_cache_size'])
 
 		self.assertEqual(0, info['stepping'])
 		self.assertEqual(0, info['model'])

--- a/tests/test_linux_debian_8_5_x86_64.py
+++ b/tests/test_linux_debian_8_5_x86_64.py
@@ -452,7 +452,7 @@ class TestLinuxDebian_8_5_X86_64(unittest.TestCase):
 	def test_returns(self):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
-		self.assertEqual(9, len(cpuinfo._get_cpu_info_from_lscpu()))
+		self.assertEqual(13, len(cpuinfo._get_cpu_info_from_lscpu()))
 		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
@@ -461,7 +461,7 @@ class TestLinuxDebian_8_5_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(16, len(cpuinfo.get_cpu_info()))
+		self.assertEqual(19, len(cpuinfo.get_cpu_info()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
@@ -476,6 +476,12 @@ class TestLinuxDebian_8_5_X86_64(unittest.TestCase):
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])
 		self.assertEqual(6, info['family'])
+
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+
+		self.assertEqual('256K', info['l2_cache_size'])
+		self.assertEqual('3072K', info['l3_cache_size'])
 
 	def test_get_cpu_info_from_dmesg(self):
 		info = cpuinfo._get_cpu_info_from_dmesg()
@@ -500,7 +506,7 @@ class TestLinuxDebian_8_5_X86_64(unittest.TestCase):
 		self.assertEqual((2800000000, 0), info['hz_advertised_raw'])
 		self.assertEqual((2793652000, 0), info['hz_actual_raw'])
 
-		self.assertEqual('3072 KB', info['l2_cache_size'])
+		self.assertEqual('3072 KB', info['l3_cache_size'])
 
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])
@@ -531,7 +537,11 @@ class TestLinuxDebian_8_5_X86_64(unittest.TestCase):
 
 		self.assertEqual('x86_64', info['raw_arch_string'])
 
-		self.assertEqual('3072 KB', info['l2_cache_size'])
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+
+		self.assertEqual('256K', info['l2_cache_size'])
+		self.assertEqual('3072 KB', info['l3_cache_size'])
 
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])

--- a/tests/test_linux_debian_8_7_1_ppc64le.py
+++ b/tests/test_linux_debian_8_7_1_ppc64le.py
@@ -422,7 +422,7 @@ class TestLinuxDebian_8_7_1_ppc64le(unittest.TestCase):
 	def test_returns(self):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
-		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_lscpu()))
+		self.assertEqual(2, len(cpuinfo._get_cpu_info_from_lscpu()))
 		self.assertEqual(5, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
@@ -431,11 +431,13 @@ class TestLinuxDebian_8_7_1_ppc64le(unittest.TestCase):
 		self.assertEqual(1, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(11, len(cpuinfo.get_cpu_info()))
+		self.assertEqual(13, len(cpuinfo.get_cpu_info()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
-		self.assertEqual(0, len(info))
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+		self.assertEqual(2, len(info))
 
 	def test_get_cpu_info_from_ibm_pa_features(self):
 		info = cpuinfo._get_cpu_info_from_ibm_pa_features()
@@ -464,6 +466,8 @@ class TestLinuxDebian_8_7_1_ppc64le(unittest.TestCase):
 		self.assertEqual('PPC_64', info['arch'])
 		self.assertEqual(64, info['bits'])
 		self.assertEqual(2, info['count'])
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
 		self.assertEqual('ppc64le', info['raw_arch_string'])
 		self.assertEqual(
 			['dabr', 'dabrx', 'dsisr', 'fpu', 'lp', 'mmu', 'pp', 'rislb', 'run', 'slb', 'sprg3'],

--- a/tests/test_linux_debian_8_x86_64.py
+++ b/tests/test_linux_debian_8_x86_64.py
@@ -87,7 +87,7 @@ class TestLinuxDebian_8_X86_64(unittest.TestCase):
 		self.assertEqual((2930000000, 0), info['hz_advertised_raw'])
 		self.assertEqual((2928283000, 0), info['hz_actual_raw'])
 
-		self.assertEqual('6144 KB', info['l2_cache_size'])
+		self.assertEqual('6144 KB', info['l3_cache_size'])
 
 		self.assertEqual(5, info['stepping'])
 		self.assertEqual(30, info['model'])
@@ -116,7 +116,7 @@ class TestLinuxDebian_8_X86_64(unittest.TestCase):
 
 		self.assertEqual('x86_64', info['raw_arch_string'])
 
-		self.assertEqual('6144 KB', info['l2_cache_size'])
+		self.assertEqual('6144 KB', info['l3_cache_size'])
 
 		self.assertEqual(5, info['stepping'])
 		self.assertEqual(30, info['model'])

--- a/tests/test_linux_fedora_24_ppc64le.py
+++ b/tests/test_linux_fedora_24_ppc64le.py
@@ -355,7 +355,7 @@ class TestLinuxFedora_24_ppc64le(unittest.TestCase):
 	def test_returns(self):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
-		self.assertEqual(1, len(cpuinfo._get_cpu_info_from_lscpu()))
+		self.assertEqual(3, len(cpuinfo._get_cpu_info_from_lscpu()))
 		self.assertEqual(5, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
@@ -364,10 +364,13 @@ class TestLinuxFedora_24_ppc64le(unittest.TestCase):
 		self.assertEqual(1, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(11, len(cpuinfo.get_cpu_info()))
+		self.assertEqual(13, len(cpuinfo.get_cpu_info()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
+
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('64K', info['l1_data_cache_size'])
 
 		self.assertEqual('POWER8E (raw), altivec supported', info['brand'])
 
@@ -398,6 +401,8 @@ class TestLinuxFedora_24_ppc64le(unittest.TestCase):
 		self.assertEqual('PPC_64', info['arch'])
 		self.assertEqual(64, info['bits'])
 		self.assertEqual(2, info['count'])
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('64K', info['l1_data_cache_size'])
 		self.assertEqual('ppc64le', info['raw_arch_string'])
 		self.assertEqual(
 			['dss_2.02', 'dss_2.05', 'dss_2.06', 'fpu', 'lsd_in_dscr', 'ppr', 'slb', 'sso_2.06', 'ugr_in_dscr'],

--- a/tests/test_linux_fedora_24_x86_64.py
+++ b/tests/test_linux_fedora_24_x86_64.py
@@ -452,7 +452,7 @@ class TestLinuxFedora_24_X86_64(unittest.TestCase):
 	def test_returns(self):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
-		self.assertEqual(9, len(cpuinfo._get_cpu_info_from_lscpu()))
+		self.assertEqual(13, len(cpuinfo._get_cpu_info_from_lscpu()))
 		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
@@ -461,7 +461,7 @@ class TestLinuxFedora_24_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(16, len(cpuinfo.get_cpu_info()))
+		self.assertEqual(19, len(cpuinfo.get_cpu_info()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
@@ -477,6 +477,12 @@ class TestLinuxFedora_24_X86_64(unittest.TestCase):
 		self.assertEqual(42, info['model'])
 		self.assertEqual(6, info['family'])
 
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+
+		self.assertEqual('256K', info['l2_cache_size'])
+		self.assertEqual('3072K', info['l3_cache_size'])
+
 	def test_get_cpu_info_from_dmesg(self):
 		info = cpuinfo._get_cpu_info_from_dmesg()
 
@@ -490,6 +496,7 @@ class TestLinuxFedora_24_X86_64(unittest.TestCase):
 		self.assertEqual(42, info['model'])
 		self.assertEqual(6, info['family'])
 
+
 	def test_get_cpu_info_from_proc_cpuinfo(self):
 		info = cpuinfo._get_cpu_info_from_proc_cpuinfo()
 
@@ -500,7 +507,7 @@ class TestLinuxFedora_24_X86_64(unittest.TestCase):
 		self.assertEqual((2800000000, 0), info['hz_advertised_raw'])
 		self.assertEqual((2793652000, 0), info['hz_actual_raw'])
 
-		self.assertEqual('3072 KB', info['l2_cache_size'])
+		self.assertEqual('3072 KB', info['l3_cache_size'])
 
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])
@@ -531,7 +538,11 @@ class TestLinuxFedora_24_X86_64(unittest.TestCase):
 
 		self.assertEqual('x86_64', info['raw_arch_string'])
 
-		self.assertEqual('3072 KB', info['l2_cache_size'])
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+
+		self.assertEqual('256K', info['l2_cache_size'])
+		self.assertEqual('3072 KB', info['l3_cache_size'])
 
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])

--- a/tests/test_linux_gentoo_2_2_x86_64.py
+++ b/tests/test_linux_gentoo_2_2_x86_64.py
@@ -455,7 +455,7 @@ class TestLinuxGentoo_2_2_X86_64(unittest.TestCase):
 	def test_returns(self):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
-		self.assertEqual(10, len(cpuinfo._get_cpu_info_from_lscpu()))
+		self.assertEqual(14, len(cpuinfo._get_cpu_info_from_lscpu()))
 		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
@@ -464,7 +464,7 @@ class TestLinuxGentoo_2_2_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(16, len(cpuinfo.get_cpu_info()))
+		self.assertEqual(19, len(cpuinfo.get_cpu_info()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
@@ -479,6 +479,12 @@ class TestLinuxGentoo_2_2_X86_64(unittest.TestCase):
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])
 		self.assertEqual(6, info['family'])
+
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+		self.assertEqual('256K', info['l2_cache_size'])
+		self.assertEqual('3072K', info['l3_cache_size'])
+
 		self.assertEqual(
 			['apic', 'clflush', 'cmov', 'constant_tsc', 'cx16', 'cx8', 'de',
 			'fpu', 'fxsr', 'ht', 'hypervisor', 'lahf_lm', 'lm', 'mca', 'mce',
@@ -513,7 +519,7 @@ class TestLinuxGentoo_2_2_X86_64(unittest.TestCase):
 		self.assertEqual((2800000000, 0), info['hz_advertised_raw'])
 		self.assertEqual((2793652000, 0), info['hz_actual_raw'])
 
-		self.assertEqual('3072 KB', info['l2_cache_size'])
+		self.assertEqual('3072 KB', info['l3_cache_size'])
 
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])
@@ -544,7 +550,10 @@ class TestLinuxGentoo_2_2_X86_64(unittest.TestCase):
 
 		self.assertEqual('x86_64', info['raw_arch_string'])
 
-		self.assertEqual('3072 KB', info['l2_cache_size'])
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+		self.assertEqual('256K', info['l2_cache_size'])
+		self.assertEqual('3072 KB', info['l3_cache_size'])
 
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])

--- a/tests/test_linux_rhel_7_3_ppc64le.py
+++ b/tests/test_linux_rhel_7_3_ppc64le.py
@@ -333,7 +333,7 @@ class TestLinuxRHEL_7_3_ppc64le(unittest.TestCase):
 	def test_returns(self):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
-		self.assertEqual(1, len(cpuinfo._get_cpu_info_from_lscpu()))
+		self.assertEqual(3, len(cpuinfo._get_cpu_info_from_lscpu()))
 		self.assertEqual(5, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
@@ -342,11 +342,12 @@ class TestLinuxRHEL_7_3_ppc64le(unittest.TestCase):
 		self.assertEqual(1, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(11, len(cpuinfo.get_cpu_info()))
+		self.assertEqual(13, len(cpuinfo.get_cpu_info()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
-
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('64K', info['l1_data_cache_size'])
 		self.assertEqual('POWER8E (raw), altivec supported', info['brand'])
 
 	def test_get_cpu_info_from_ibm_pa_features(self):
@@ -374,6 +375,8 @@ class TestLinuxRHEL_7_3_ppc64le(unittest.TestCase):
 		self.assertEqual((3425000000, 0), info['hz_advertised_raw'])
 		self.assertEqual((3425000000, 0), info['hz_actual_raw'])
 		self.assertEqual('PPC_64', info['arch'])
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('64K', info['l1_data_cache_size'])
 		self.assertEqual(64, info['bits'])
 		self.assertEqual(16, info['count'])
 		self.assertEqual('ppc64le', info['raw_arch_string'])

--- a/tests/test_linux_ubuntu_16_04_x86_64.py
+++ b/tests/test_linux_ubuntu_16_04_x86_64.py
@@ -456,7 +456,7 @@ class TestLinuxUbuntu_16_04_X86_64(unittest.TestCase):
 	def test_returns(self):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
-		self.assertEqual(10, len(cpuinfo._get_cpu_info_from_lscpu()))
+		self.assertEqual(14, len(cpuinfo._get_cpu_info_from_lscpu()))
 		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
@@ -465,7 +465,7 @@ class TestLinuxUbuntu_16_04_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(16, len(cpuinfo.get_cpu_info()))
+		self.assertEqual(19, len(cpuinfo.get_cpu_info()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
@@ -480,6 +480,11 @@ class TestLinuxUbuntu_16_04_X86_64(unittest.TestCase):
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])
 		self.assertEqual(6, info['family'])
+
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+		self.assertEqual('256K', info['l2_cache_size'])
+		self.assertEqual('3072K', info['l3_cache_size'])
 		self.assertEqual(
 			['acpi', 'aperfmperf', 'apic', 'arat', 'arch_perfmon', 'bts',
 			'clflush', 'cmov', 'constant_tsc', 'cx16', 'cx8', 'de', 'ds_cpl',
@@ -519,7 +524,7 @@ class TestLinuxUbuntu_16_04_X86_64(unittest.TestCase):
 		self.assertEqual((2800000000, 0), info['hz_advertised_raw'])
 		self.assertEqual((1901375000, 0), info['hz_actual_raw'])
 
-		self.assertEqual('3072 KB', info['l2_cache_size'])
+		self.assertEqual('3072 KB', info['l3_cache_size'])
 
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])
@@ -555,7 +560,12 @@ class TestLinuxUbuntu_16_04_X86_64(unittest.TestCase):
 
 		self.assertEqual('x86_64', info['raw_arch_string'])
 
-		self.assertEqual('3072 KB', info['l2_cache_size'])
+		self.assertEqual('32K', info['l1_instruction_cache_size'])
+		self.assertEqual('32K', info['l1_data_cache_size'])
+
+		self.assertEqual('256K', info['l2_cache_size'])
+
+		self.assertEqual('3072 KB', info['l3_cache_size'])
 
 		self.assertEqual(7, info['stepping'])
 		self.assertEqual(42, info['model'])


### PR DESCRIPTION
…stead

I have added support for retrieving L1, L2 and L3 cache sizes from `lscpu`, and corrected the erroneous reporting from `proc/cpuinfo`. `lscpu` is not always 100% accurate on all CPUs, but it should report factory settings at least for the most part (since `lscpu` reads from `sysfs` directly).

I also linted out some extraneous print statements. I'll revert that if desired. 