### PR TITLE
_friendly_bytes_to_int: fix for floats and input with [GMK]iB units

### DIFF
--- a/cpuinfo/cpuinfo.py
+++ b/cpuinfo/cpuinfo.py
@@ -594,6 +594,10 @@ def _friendly_bytes_to_int(friendly_bytes):
 		'mb' : 1024 * 1024,
 		'kb' : 1024,
 
+		'gib' : 1024 * 1024 * 1024,
+		'mib' : 1024 * 1024,
+		'kib' : 1024,
+
 		'g' : 1024 * 1024 * 1024,
 		'm' : 1024 * 1024,
 		'k' : 1024,
@@ -603,7 +607,7 @@ def _friendly_bytes_to_int(friendly_bytes):
 	try:
 		for pattern, multiplier in formats.items():
 			if input.endswith(pattern):
-				return int(input.split(pattern)[0].strip()) * multiplier
+				return int(float(input.split(pattern)[0].strip()) * multiplier)
 
 	except Exception as err:
 		pass


### PR DESCRIPTION
On my laptop, `cpuinfo` returns the `l2_cache_size` not as `int` but as `string`. Investigating this, I found two problems with `_friendly_bytes_to_int()`:
* `lscpu` uses [GMK]iB units on my laptop, which were not covered by `_friendly_bytes_to_int()` yet
* if input is a floating point number the int conversion failed.

These two problems resulting in returning a string instead of an int. This PR tries to fix this.

And as an example, the output of `lscpu` from my laptop:
```bash
$ lscpu 
Architecture:                    x86_64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
Address sizes:                   39 bits physical, 48 bits virtual
CPU(s):                          12
On-line CPU(s) list:             0-11
Thread(s) per core:              2
Core(s) per socket:              6
Socket(s):                       1
NUMA node(s):                    1
Vendor ID:                       GenuineIntel
CPU family:                      6
Model:                           165
Model name:                      Intel(R) Core(TM) i7-10750H CPU @ 2.60GHz
Stepping:                        2
CPU MHz:                         2600.000
CPU max MHz:                     5000.0000
CPU min MHz:                     800.0000
BogoMIPS:                        5202.65
Virtualization:                  VT-x
L1d cache:                       192 KiB
L1i cache:                       192 KiB
L2 cache:                        1.5 MiB
L3 cache:                        12 MiB
NUMA node0 CPU(s):               0-11
Vulnerability Itlb multihit:     KVM: Mitigation: VMX disabled
Vulnerability L1tf:              Not affected
Vulnerability Mds:               Not affected
Vulnerability Meltdown:          Not affected
Vulnerability Spec store bypass: Mitigation; Speculative Store Bypass disabled via prctl and seccomp
Vulnerability Spectre v1:        Mitigation; usercopy/swapgs barriers and __user pointer sanitization
Vulnerability Spectre v2:        Mitigation; Enhanced IBRS, IBPB conditional, RSB filling
Vulnerability Srbds:             Not affected
Vulnerability Tsx async abort:   Not affected
Flags:                           fpu vme de pse tsc msr pae mce cx8 apic sep mtrr pge mca cmov pat pse36 clflush dts acpi mmx fxsr sse sse2 ss ht tm pbe syscall nx pdpe1gb rdtscp lm constant_tsc art arch_perfmon pebs bts rep_good nopl xtopology nonstop_tsc cpuid aperfmperf pni pclmulqdq dtes64 monitor ds_cpl vmx est tm2 ssse3 sdbg fma cx16 xtpr pdcm pcid sse4_1 
                                 sse4_2 x2apic movbe popcnt tsc_deadline_timer aes xsave avx f16c rdrand lahf_lm abm 3dnowprefetch cpuid_fault epb invpcid_single ssbd ibrs ibpb stibp ibrs_enhanced tpr_shadow vnmi flexpriority ept vpid ept_ad fsgsbase tsc_adjust sgx bmi1 avx2 smep bmi2 erms invpcid mpx rdseed adx smap clflushopt intel_pt xsaveopt xsavec xgetbv1 x
                                 saves dtherm ida arat pln pts hwp hwp_notify hwp_act_window hwp_epp pku ospke sgx_lc md_clear flush_l1d arch_capabilities
```