### PR TITLE
Add socket count

### DIFF
--- a/cpuinfo/cpuinfo.py
+++ b/cpuinfo/cpuinfo.py
@@ -430,7 +430,10 @@ def _copy_new_fields(info, new_info):
 				if f not in info['flags']: info['flags'].append(f)
 			info['flags'].sort()
 
-def _get_field_actual(cant_be_number, raw_string, field_names):
+def _get_field_actual(cant_be_number, get_max, raw_string, field_names):
+	if get_max:
+			max_value = -1
+
 	for line in raw_string.splitlines():
 		for field_name in field_names:
 			field_name = field_name.lower()
@@ -443,45 +446,19 @@ def _get_field_actual(cant_be_number, raw_string, field_names):
 						if not right.isdigit():
 							return right
 					else:
-						return right
+						if not get_max:
+							return right
+						if int(right) > max_value:
+							max_value = int(right)
+
+	if get_max and max_value != -1:
+		return max_value
 
 	return None
 
-def _get_field_actual_max(raw_string, field_names):
-	max_value = -1
-	for line in raw_string.splitlines():
-		for field_name in field_names:
-			field_name = field_name.lower()
-			if ':' in line:
-				left, right = line.split(':', 1)
-				left = left.strip().lower()
-				right = right.strip()
-				if left == field_name and len(right) > 0:
-					if int(right) > max_value:
-						max_value = int(right)
-	if max_value != -1:
-		return max_value
-	
-	return  None
 
-def _get_field(cant_be_number, raw_string, convert_to, default_value, *field_names):
-	retval = _get_field_actual(cant_be_number, raw_string, field_names)
-
-	# Convert the return value
-	if retval and convert_to:
-		try:
-			retval = convert_to(retval)
-		except:
-			retval = default_value
-
-	# Return the default if there is no return value
-	if retval is None:
-		retval = default_value
-
-	return retval
-
-def _get_field_max(raw_string, convert_to, default_value, *field_names):
-	retval = _get_field_actual_max(raw_string, field_names)
+def _get_field(cant_be_number, get_max, raw_string, convert_to, default_value, *field_names):
+	retval = _get_field_actual(cant_be_number, get_max, raw_string, field_names)
 
 	# Convert the return value
 	if retval and convert_to:
@@ -1757,18 +1734,18 @@ def _get_cpu_info_from_proc_cpuinfo():
 			return {}
 
 		# Various fields
-		vendor_id = _get_field(False, output, None, '', 'vendor_id', 'vendor id', 'vendor')
-		processor_brand = _get_field(True, output, None, None, 'model name', 'cpu', 'processor', 'uarch')
-		cache_size = _get_field(False, output, None, '', 'cache size')
-		stepping = _get_field(False, output, int, 0, 'stepping')
-		model = _get_field(False, output, int, 0, 'model')
-		family = _get_field(False, output, int, 0, 'cpu family')
-		hardware = _get_field(False, output, None, '', 'Hardware')
-		socket_count = _get_field_max(output,int,None,'physical id')
+		vendor_id = _get_field(False, False, output, None, '', 'vendor_id', 'vendor id', 'vendor')
+		processor_brand = _get_field(True, False, output, None, None, 'model name', 'cpu', 'processor', 'uarch')
+		cache_size = _get_field(False, False, output, None, '', 'cache size')
+		stepping = _get_field(False, False, output, int, 0, 'stepping')
+		model = _get_field(False, False, output, int, 0, 'model')
+		family = _get_field(False, False, output, int, 0, 'cpu family')
+		hardware = _get_field(False, False, output, None, '', 'Hardware')
+		socket_count = _get_field(False, True, output, int, None, 'physical id')
 		if socket_count != None : socket_count += 1
 
 		# Flags
-		flags = _get_field(False, output, None, None, 'flags', 'Features', 'ASEs implemented')
+		flags = _get_field(False, False, output, None, None, 'flags', 'Features', 'ASEs implemented')
 		if flags:
 			flags = flags.split()
 			flags.sort()
@@ -1778,7 +1755,7 @@ def _get_cpu_info_from_proc_cpuinfo():
 			try:
 				for i in range(0, 10):
 					name = "cache{0}".format(i)
-					value = _get_field(False, output, None, None, name)
+					value = _get_field(False, False, output, None, None, name)
 					if value:
 						value = [entry.split('=') for entry in value.split(' ')]
 						value = dict(value)
@@ -1789,7 +1766,7 @@ def _get_cpu_info_from_proc_cpuinfo():
 				pass
 
 		# Convert from MHz string to Hz
-		hz_actual = _get_field(False, output, None, '', 'cpu MHz', 'cpu speed', 'clock', 'cpu MHz dynamic', 'cpu MHz static')
+		hz_actual = _get_field(False, False, output, None, '', 'cpu MHz', 'cpu speed', 'clock', 'cpu MHz dynamic', 'cpu MHz static')
 		hz_actual = hz_actual.lower().rstrip('mhz').strip()
 		hz_actual = _to_decimal_string(hz_actual)
 
@@ -1903,7 +1880,7 @@ def _get_cpu_info_from_lscpu():
 
 		info = {}
 
-		new_hz = _get_field(False, output, None, None, 'CPU max MHz', 'CPU MHz')
+		new_hz = _get_field(False, False, output, None, None, 'CPU max MHz', 'CPU MHz')
 		if new_hz:
 			new_hz = _to_decimal_string(new_hz)
 			scale = 6
@@ -1912,7 +1889,7 @@ def _get_cpu_info_from_lscpu():
 			info['hz_advertised'] = _hz_short_to_full(new_hz, scale)
 			info['hz_actual'] = _hz_short_to_full(new_hz, scale)
 
-		new_hz = _get_field(False, output, None, None, 'CPU dynamic MHz', 'CPU static MHz')
+		new_hz = _get_field(False, False, output, None, None, 'CPU dynamic MHz', 'CPU static MHz')
 		if new_hz:
 			new_hz = _to_decimal_string(new_hz)
 			scale = 6
@@ -1921,48 +1898,48 @@ def _get_cpu_info_from_lscpu():
 			info['hz_advertised'] = _hz_short_to_full(new_hz, scale)
 			info['hz_actual'] = _hz_short_to_full(new_hz, scale)
 
-		vendor_id = _get_field(False, output, None, None, 'Vendor ID')
+		vendor_id = _get_field(False, False, output, None, None, 'Vendor ID')
 		if vendor_id:
 			info['vendor_id_raw'] = vendor_id
 
-		brand = _get_field(False, output, None, None, 'Model name')
+		brand = _get_field(False, False, output, None, None, 'Model name')
 		if brand:
 			info['brand_raw'] = brand
 		else:
-			brand = _get_field(False, output, None, None, 'Model')
+			brand = _get_field(False, False, output, None, None, 'Model')
 			if brand and not brand.isdigit():
 				info['brand_raw'] = brand
 
-		family = _get_field(False, output, None, None, 'CPU family')
+		family = _get_field(False, False, output, None, None, 'CPU family')
 		if family and family.isdigit():
 			info['family'] = int(family)
 
-		stepping = _get_field(False, output, None, None, 'Stepping')
+		stepping = _get_field(False, False, output, None, None, 'Stepping')
 		if stepping and stepping.isdigit():
 			info['stepping'] = int(stepping)
 
-		model = _get_field(False, output, None, None, 'Model')
+		model = _get_field(False, False, output, None, None, 'Model')
 		if model and model.isdigit():
 			info['model'] = int(model)
 
-		l1_data_cache_size = _get_field(False, output, None, None, 'L1d cache')
+		l1_data_cache_size = _get_field(False, False, output, None, None, 'L1d cache')
 		if l1_data_cache_size:
 			info['l1_data_cache_size'] = _friendly_bytes_to_int(l1_data_cache_size)
 
-		l1_instruction_cache_size = _get_field(False, output, None, None, 'L1i cache')
+		l1_instruction_cache_size = _get_field(False, False, output, None, None, 'L1i cache')
 		if l1_instruction_cache_size:
 			info['l1_instruction_cache_size'] = _friendly_bytes_to_int(l1_instruction_cache_size)
 
-		l2_cache_size = _get_field(False, output, None, None, 'L2 cache', 'L2d cache')
+		l2_cache_size = _get_field(False, False, output, None, None, 'L2 cache', 'L2d cache')
 		if l2_cache_size:
 			info['l2_cache_size'] = _friendly_bytes_to_int(l2_cache_size)
 
-		l3_cache_size = _get_field(False, output, None, None, 'L3 cache')
+		l3_cache_size = _get_field(False, False, output, None, None, 'L3 cache')
 		if l3_cache_size:
 			info['l3_cache_size'] = _friendly_bytes_to_int(l3_cache_size)
 
 		# Flags
-		flags = _get_field(False, output, None, None, 'flags', 'Features', 'ASEs implemented')
+		flags = _get_field(False, False, output, None, None, 'flags', 'Features', 'ASEs implemented')
 		if flags:
 			flags = flags.split()
 			flags.sort()
@@ -2180,22 +2157,22 @@ def _get_cpu_info_from_sysctl():
 			return {}
 
 		# Various fields
-		vendor_id = _get_field(False, output, None, None, 'machdep.cpu.vendor')
-		processor_brand = _get_field(True, output, None, None, 'machdep.cpu.brand_string')
-		cache_size = _get_field(False, output, int, 0, 'machdep.cpu.cache.size')
-		stepping = _get_field(False, output, int, 0, 'machdep.cpu.stepping')
-		model = _get_field(False, output, int, 0, 'machdep.cpu.model')
-		family = _get_field(False, output, int, 0, 'machdep.cpu.family')
+		vendor_id = _get_field(False, False, output, None, None, 'machdep.cpu.vendor')
+		processor_brand = _get_field(True, False, output, None, None, 'machdep.cpu.brand_string')
+		cache_size = _get_field(False, False, output, int, 0, 'machdep.cpu.cache.size')
+		stepping = _get_field(False, False, output, int, 0, 'machdep.cpu.stepping')
+		model = _get_field(False, False, output, int, 0, 'machdep.cpu.model')
+		family = _get_field(False, False, output, int, 0, 'machdep.cpu.family')
 
 		# Flags
-		flags = _get_field(False, output, None, '', 'machdep.cpu.features').lower().split()
-		flags.extend(_get_field(False, output, None, '', 'machdep.cpu.leaf7_features').lower().split())
-		flags.extend(_get_field(False, output, None, '', 'machdep.cpu.extfeatures').lower().split())
+		flags = _get_field(False, False, output, None, '', 'machdep.cpu.features').lower().split()
+		flags.extend(_get_field(False, False, output, None, '', 'machdep.cpu.leaf7_features').lower().split())
+		flags.extend(_get_field(False, False, output, None, '', 'machdep.cpu.extfeatures').lower().split())
 		flags.sort()
 
 		# Convert from GHz/MHz string to Hz
 		hz_advertised, scale = _parse_cpu_brand_string(processor_brand)
-		hz_actual = _get_field(False, output, None, None, 'hw.cpufrequency')
+		hz_actual = _get_field(False, False, output, None, None, 'hw.cpufrequency')
 		hz_actual = _to_decimal_string(hz_actual)
 
 		info = {
@@ -2254,9 +2231,9 @@ def _get_cpu_info_from_sysinfo_v1():
 			return {}
 
 		# Various fields
-		vendor_id = '' #_get_field(False, output, None, None, 'CPU #0: ')
+		vendor_id = '' #_get_field(False, False, output, None, None, 'CPU #0: ')
 		processor_brand = output.split('CPU #0: "')[1].split('"\n')[0].strip()
-		cache_size = '' #_get_field(False, output, None, None, 'machdep.cpu.cache.size')
+		cache_size = '' #_get_field(False, False, output, None, None, 'machdep.cpu.cache.size')
 		stepping = int(output.split(', stepping ')[1].split(',')[0].strip())
 		model = int(output.split(', model ')[1].split(',')[0].strip())
 		family = int(output.split(', family ')[1].split(',')[0].strip())
@@ -2319,9 +2296,9 @@ def _get_cpu_info_from_sysinfo_v2():
 			return {}
 
 		# Various fields
-		vendor_id = '' #_get_field(False, output, None, None, 'CPU #0: ')
+		vendor_id = '' #_get_field(False, False, output, None, None, 'CPU #0: ')
 		processor_brand = output.split('CPU #0: "')[1].split('"\n')[0].strip()
-		cache_size = '' #_get_field(False, output, None, None, 'machdep.cpu.cache.size')
+		cache_size = '' #_get_field(False, False, output, None, None, 'machdep.cpu.cache.size')
 		signature = output.split('Signature:')[1].split('\n')[0].strip()
 		#
 		stepping = int(signature.split('stepping ')[1].split(',')[0].strip())

--- a/tests/test_linux_debian_8_5_x86_64.py
+++ b/tests/test_linux_debian_8_5_x86_64.py
@@ -454,7 +454,7 @@ class TestLinuxDebian_8_5_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
 		self.assertEqual(13, len(cpuinfo._get_cpu_info_from_lscpu()))
-		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
+		self.assertEqual(12, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
 		self.assertEqual(8, len(cpuinfo._get_cpu_info_from_dmesg()))
@@ -462,7 +462,7 @@ class TestLinuxDebian_8_5_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(21, len(cpuinfo._get_cpu_info_internal()))
+		self.assertEqual(22, len(cpuinfo._get_cpu_info_internal()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
@@ -522,6 +522,8 @@ class TestLinuxDebian_8_5_X86_64(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])
+
 
 	def test_all(self):
 		info = cpuinfo._get_cpu_info_internal()
@@ -557,3 +559,4 @@ class TestLinuxDebian_8_5_X86_64(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])

--- a/tests/test_linux_debian_8_x86_64.py
+++ b/tests/test_linux_debian_8_x86_64.py
@@ -68,7 +68,7 @@ class TestLinuxDebian_8_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_lscpu()))
-		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
+		self.assertEqual(12, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_dmesg()))
@@ -76,7 +76,7 @@ class TestLinuxDebian_8_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(18, len(cpuinfo._get_cpu_info_internal()))
+		self.assertEqual(19, len(cpuinfo._get_cpu_info_internal()))
 
 	def test_get_cpu_info_from_proc_cpuinfo(self):
 		info = cpuinfo._get_cpu_info_from_proc_cpuinfo()
@@ -101,6 +101,7 @@ class TestLinuxDebian_8_X86_64(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])
 
 	def test_all(self):
 		info = cpuinfo._get_cpu_info_internal()
@@ -130,3 +131,4 @@ class TestLinuxDebian_8_X86_64(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])

--- a/tests/test_linux_fedora_24_x86_64.py
+++ b/tests/test_linux_fedora_24_x86_64.py
@@ -454,7 +454,7 @@ class TestLinuxFedora_24_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
 		self.assertEqual(13, len(cpuinfo._get_cpu_info_from_lscpu()))
-		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
+		self.assertEqual(12, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
 		self.assertEqual(8, len(cpuinfo._get_cpu_info_from_dmesg()))
@@ -462,7 +462,7 @@ class TestLinuxFedora_24_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(21, len(cpuinfo._get_cpu_info_internal()))
+		self.assertEqual(22, len(cpuinfo._get_cpu_info_internal()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()

--- a/tests/test_linux_fedora_29_x86_64_ryzen_7.py
+++ b/tests/test_linux_fedora_29_x86_64_ryzen_7.py
@@ -453,7 +453,7 @@ class Test_Linux_Fedora_29_X86_64_Ryzen_7(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
 		self.assertEqual(14, len(cpuinfo._get_cpu_info_from_lscpu()))
-		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
+		self.assertEqual(12, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_dmesg()))
@@ -461,7 +461,7 @@ class Test_Linux_Fedora_29_X86_64_Ryzen_7(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(21, len(cpuinfo._get_cpu_info_internal()))
+		self.assertEqual(22, len(cpuinfo._get_cpu_info_internal()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
@@ -527,6 +527,7 @@ class Test_Linux_Fedora_29_X86_64_Ryzen_7(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])
 
 	def test_all(self):
 		info = cpuinfo._get_cpu_info_internal()
@@ -568,3 +569,4 @@ class Test_Linux_Fedora_29_X86_64_Ryzen_7(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])

--- a/tests/test_linux_gentoo_2_2_x86_64.py
+++ b/tests/test_linux_gentoo_2_2_x86_64.py
@@ -457,7 +457,7 @@ class TestLinuxGentoo_2_2_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
 		self.assertEqual(14, len(cpuinfo._get_cpu_info_from_lscpu()))
-		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
+		self.assertEqual(12, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
 		self.assertEqual(8, len(cpuinfo._get_cpu_info_from_dmesg()))
@@ -465,7 +465,7 @@ class TestLinuxGentoo_2_2_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(21, len(cpuinfo._get_cpu_info_internal()))
+		self.assertEqual(22, len(cpuinfo._get_cpu_info_internal()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
@@ -535,6 +535,7 @@ class TestLinuxGentoo_2_2_X86_64(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])
 
 	def test_all(self):
 		info = cpuinfo._get_cpu_info_internal()
@@ -569,3 +570,4 @@ class TestLinuxGentoo_2_2_X86_64(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])

--- a/tests/test_linux_ubuntu_16_04_x86_64.py
+++ b/tests/test_linux_ubuntu_16_04_x86_64.py
@@ -458,7 +458,7 @@ class TestLinuxUbuntu_16_04_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_registry()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpufreq_info()))
 		self.assertEqual(14, len(cpuinfo._get_cpu_info_from_lscpu()))
-		self.assertEqual(11, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
+		self.assertEqual(12, len(cpuinfo._get_cpu_info_from_proc_cpuinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysctl()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_kstat()))
 		self.assertEqual(8, len(cpuinfo._get_cpu_info_from_dmesg()))
@@ -466,7 +466,7 @@ class TestLinuxUbuntu_16_04_X86_64(unittest.TestCase):
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_ibm_pa_features()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_sysinfo()))
 		self.assertEqual(0, len(cpuinfo._get_cpu_info_from_cpuid()))
-		self.assertEqual(21, len(cpuinfo._get_cpu_info_internal()))
+		self.assertEqual(22, len(cpuinfo._get_cpu_info_internal()))
 
 	def test_get_cpu_info_from_lscpu(self):
 		info = cpuinfo._get_cpu_info_from_lscpu()
@@ -545,6 +545,7 @@ class TestLinuxUbuntu_16_04_X86_64(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])
 
 	def test_all(self):
 		info = cpuinfo._get_cpu_info_internal()
@@ -586,3 +587,4 @@ class TestLinuxUbuntu_16_04_X86_64(unittest.TestCase):
 			,
 			info['flags']
 		)
+		self.assertEqual(1, info['socket_count'])


### PR DESCRIPTION
Hi,

Thanks for your work, we are using your library to retrieve hardware information which we use to estimate environmental impact of pools of servers. Your work has saved us a lot of time, thanks again.

Adding the socket count retrieved from `/proc/cpuinfo`.

A patch was needed on the functions: `_get_field()`, `_get_field_actual()` in order to retrieve the max value of a 
given field.

Tests have been adapted and are all passing.

Don't hesitate to contact me for any further information or adaptation.