### PR TITLE
Avoid mutable default arguments

### DIFF
--- a/cpuinfo/cpuinfo.py
+++ b/cpuinfo/cpuinfo.py
@@ -905,7 +905,7 @@ def _filter_dict_keys_with_empty_values(info, acceptable_values = {}):
 	return filtered_info
 
 class ASM:
-	def __init__(self, restype=None, argtypes=(), machine_code=[]):
+	def __init__(self, restype=None, argtypes=(), machine_code=None):
 		self.restype = restype
 		self.argtypes = argtypes
 		self.machine_code = machine_code
@@ -1000,7 +1000,7 @@ class CPUID:
 		# Figure out if SE Linux is on and in enforcing mode
 		self.is_selinux_enforcing = _is_selinux_enforcing(trace)
 
-	def _asm_func(self, restype=None, argtypes=(), machine_code=[]):
+	def _asm_func(self, restype=None, argtypes=(), machine_code=None):
 		asm = ASM(restype, argtypes, machine_code)
 		asm.compile()
 		return asm

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -269,7 +269,7 @@ def monkey_patch_cpuid(cpuinfo, return_hz, return_values):
 		_counter = 0
 		_is_first = False
 
-		def _asm_func(self, restype=None, argtypes=(), machine_code=[]):
+		def _asm_func(self, restype=None, argtypes=(), machine_code=None):
 			class CPUIDGetTicks:
 				# NOTE: This assumes that the function returned is a get_ticks function
 				def func(self):

--- a/tests/test_cpuid.py
+++ b/tests/test_cpuid.py
@@ -8,7 +8,7 @@ import helpers
 class MockASM(ASM):
 	is_first = False
 
-	def __init__(self, restype=None, argtypes=(), machine_code=[]):
+	def __init__(self, restype=None, argtypes=(), machine_code=None):
 		super(MockASM, self).__init__(restype, argtypes, machine_code)
 
 	def compile(self):

--- a/tools/get_system_info.py
+++ b/tools/get_system_info.py
@@ -296,7 +296,7 @@ if 'winreg' in sys.modules or '_winreg' in sys.modules:
 
 
 class ASM:
-	def __init__(self, restype=None, argtypes=(), machine_code=[]):
+	def __init__(self, restype=None, argtypes=(), machine_code=None):
 		self.restype = restype
 		self.argtypes = argtypes
 		self.machine_code = machine_code
@@ -392,7 +392,7 @@ class CPUID:
 		# Figure out if SE Linux is on and in enforcing mode
 		self.is_selinux_enforcing = _is_selinux_enforcing()
 
-	def _asm_func(self, restype=None, argtypes=(), machine_code=[]):
+	def _asm_func(self, restype=None, argtypes=(), machine_code=None):
 		asm = ASM(restype, argtypes, machine_code)
 		asm.compile()
 		return asm


### PR DESCRIPTION
* [Common Gotchas | The Hitchhiker’s Guide to Python](https://docs.python-guide.org/writing/gotchas/#mutable-default-arguments)
* [Python Pitfall: Mutable Default Arguments](https://towardsdatascience.com/python-pitfall-mutable-default-arguments-9385e8265422)
* [Python Mutable Defaults Are The Source of All Evil](https://florimond.dev/en/posts/2018/08/python-mutable-defaults-are-the-source-of-all-evil/)