### PR TITLE
Migrate setup.py → pyproject.toml

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -29,4 +29,4 @@ jobs:
         python -m pip install --upgrade pip
     - name: Run tests
       run: |
-        python setup.py test
+        python test_suite.py

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,29 @@
 [build-system]
-requires = [
-    "setuptools",
-]
+requires = ["setuptools>=64.0.0", "setuptools-scm"]
 build-backend = "setuptools.build_meta"
+
+
+[project]
+name = "py-cpuinfo"
+version = "9.0.0"
+description = "Get CPU info with pure Python"
+license = {text = "MIT"}
+authors = [
+    {name = "Matthew Brennan Jones", email = "matthew.brennan.jones@gmail.com"}
+]
+readme = "README.rst"
+requires-python = ">=3"
+classifiers=[
+    "Development Status :: 5 - Production/Stable",
+    "Topic :: Utilities",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3"
+]
+packages=["cpuinfo"]
+
+[project.urls]
+homepage = "https://github.com/workhorsy/py-cpuinfo"
+repository = "https://github.com/workhorsy/py-cpuinfo.git"
+
+[project.scripts]
+cpuinfo = "cpuinfo:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,6 @@
 [build-system]
-requires = ["setuptools>=64.0.0", "setuptools-scm"]
+requires = ["setuptools>=61.0"]
 build-backend = "setuptools.build_meta"
-
 
 [project]
 name = "py-cpuinfo"
@@ -11,7 +10,7 @@ license = {text = "MIT"}
 authors = [
     {name = "Matthew Brennan Jones", email = "matthew.brennan.jones@gmail.com"}
 ]
-readme = "README.rst"
+readme = "README.md"
 requires-python = ">=3"
 classifiers=[
     "Development Status :: 5 - Production/Stable",
@@ -22,8 +21,13 @@ classifiers=[
 packages=["cpuinfo"]
 
 [project.urls]
-homepage = "https://github.com/workhorsy/py-cpuinfo"
-repository = "https://github.com/workhorsy/py-cpuinfo.git"
+Homepage = "https://github.com/workhorsy/py-cpuinfo"
+Repository = "https://github.com/workhorsy/py-cpuinfo.git"
+Issues = "https://github.com/workhorsy/py-cpuinfo/issues"
+Changelog = "https://github.com/workhorsy/py-cpuinfo/blob/master/ChangeLog"
 
 [project.scripts]
 cpuinfo = "cpuinfo:main"
+
+[tool.distutils.bdist_wheel]
+universal = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[bdist_wheel]
-universal = 0

--- a/setup.py
+++ b/setup.py
@@ -1,33 +1,10 @@
+#!/usr/bin/env python
 # Copyright (c) 2014-2022 Matthew Brennan Jones <matthew.brennan.jones@gmail.com>
 # Py-cpuinfo gets CPU info with pure Python
 # It uses the MIT License
 # It is hosted at: https://github.com/workhorsy/py-cpuinfo
 
-import os
 from setuptools import setup
 
-with open(os.path.join(os.getcwd(), 'README.rst')) as f:
-    readme_content = f.read()
-
-setup(
-    name = "py-cpuinfo",
-    version = "9.0.0",
-    author = "Matthew Brennan Jones",
-    author_email = "matthew.brennan.jones@gmail.com",
-    description = "Get CPU info with pure Python",
-    long_description=readme_content,
-    python_requires='>=3',
-    license = "MIT",
-    url = "https://github.com/workhorsy/py-cpuinfo",
-    packages=['cpuinfo'],
-    test_suite="test_suite",
-    entry_points = {
-        'console_scripts': ['cpuinfo = cpuinfo:main'],
-    },
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Topic :: Utilities",
-        "License :: OSI Approved :: MIT License",
-        "Programming Language :: Python :: 3"
-    ],
-)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
See [PEP 621](https://peps.python.org/pep-0621/) and [PEP 518](https://peps.python.org/pep-0518/).

Keep setup.py for legacy installs.
The proper way to install is now: pip install