### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -18,9 +18,9 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
         architecture: ${{ matrix.architecture }}


### PR DESCRIPTION
[actions/checkout](https://github.com/actions/checkout/tags)
[actions/setup-python](https://github.com/actions/setup-python/tags)

From the CI test jobs:
```
▾ Run actions/setup-python@v2
  with:
    python-version: 3.9
    architecture: x64
    token: ***
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```