### PR TITLE
Python 3.12

### DIFF
--- a/.github/workflows/python-test.yml
+++ b/.github/workflows/python-test.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macOS-latest]
-        python-version: ["3.7", "3.9", "3.10", "3.11"]
+        python-version: ["3.7", "3.9", "3.10", "3.11", "3.12", "3.13"]
         architecture: [x64, x86]
         exclude:
           - os: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
         architecture: ${{ matrix.architecture }}
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip
+        python -m pip install --upgrade pip setuptools
     - name: Run tests
       run: |
         python setup.py test


### PR DESCRIPTION
Starting with Python [3.12](https://docs.python.org/3/whatsnew/3.12.html), we have to explicitly install [`setuptools`](https://github.com/pypa/setuptools):
> * [gh-95299](https://github.com/python/cpython/issues/95299): Do not pre-install `setuptools` in virtual environments created with [`venv`](https://docs.python.org/3/library/venv.html#module-venv). This means that `distutils`, `setuptools`, `pkg_resources`, and `easy_install` will no longer available by default; to access these run `pip install setuptools` in the [activated](https://docs.python.org/3/library/venv.html#venv-explanation) virtual environment.